### PR TITLE
xonotic: fix a couple of bugs

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -1,160 +1,93 @@
-{ lib, stdenv, fetchurl, fetchzip, makeWrapper, runCommandNoCC, makeDesktopItem
-, xonotic-data
-, # required for both
-  unzip, libjpeg, zlib, libvorbis, curl
-, # glx
-  libX11, libGLU, libGL, libXpm, libXext, libXxf86vm, alsaLib
-, # sdl
-  SDL2
+{ lib, stdenv, fetchurl, pkgs, zip, ...}:
 
-, withSDL ? true
-, withGLX ? false
-, withDedicated ? true
-}:
-
-let
-  pname = "xonotic";
+stdenv.mkDerivation rec {
+  name = "xonotic";
   version = "0.8.2";
-  name = "${pname}-${version}";
-  variant =
-    if withSDL && withGLX then
-      ""
-    else if withSDL then
-      "-sdl"
-    else if withGLX then
-      "-glx"
-    else if withDedicated then
-      "-dedicated"
-    else "-what-even-am-i";
 
-  meta = {
-    description = "A free fast-paced first-person shooter";
-    longDescription = ''
-      Xonotic is a free, fast-paced first-person shooter that works on
-      Windows, macOS and Linux. The project is geared towards providing
-      addictive arena shooter gameplay which is all spawned and driven
-      by the community itself. Xonotic is a direct successor of the
-      Nexuiz project with years of development between them, and it
-      aims to become the best possible open-source FPS of its kind.
-    '';
-    homepage = "https://www.xonotic.org/";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ astsmtl zalakain petabyteboy ];
-    platforms = stdenv.lib.platforms.linux;
+  #   src = fetchurl {
+  #     url = "https://xonotic:g-23@beta.xonotic.org/autobuild/Xonotic-20200607.zip";
+  #     sha256 = "1fw3sn3zn3b5ryrpjmsljy01qvbihnvz3zrmpxjv1mrcp9rh23dj";
+  #   };
+  src = fetchurl {
+    url = "https://dl.xonotic.org/xonotic-0.8.2.zip";
+    sha256 = "1mcs6l4clvn7ibfq3q69k2p0z6ww75rxvnngamdq5ic6yhq74bx2";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "xonotic";
-    exec = "$out/bin/xonotic";
-    comment = meta.description;
-    desktopName = "Xonotic";
-    categories = "Game;Shooter;";
-    icon = "xonotic";
-    startupNotify = "false";
-  };
+  # TODO: libtheora libvorbisenc libogg
+  # libpng16
 
-  xonotic-unwrapped = stdenv.mkDerivation rec {
-    pname = "xonotic${variant}-unwrapped";
-    inherit version;
+  buildInputs = with pkgs; [ 
+    unzip zip gmp SDL2 openssl which
+    git bash zlib gcc
+    libjpeg xorg.libXpm 
+    xorg.libX11 libGLU 
+    libGL xorg.libXext freetype
+    xorg.libXxf86vm alsaLib 
+    curl libvorbis libGL 
+    libtheora libvorbis libogg 
+    libpng pkg-config 
+    stdenv.cc.cc autoPatchelfHook ];
 
-    src = fetchurl {
-      url = "https://dl.xonotic.org/${name}-source.zip";
-      sha256 = "0axxw04fyz6jlfqd0kp7hdrqa0li31sx1pbipf2j5qp9wvqicsay";
-    };
+  nativeBuildInputs = with pkgs; [
+    zip 
+  ];
 
-    buildInputs = [ unzip libjpeg zlib libvorbis curl ]
-      ++ lib.optional withGLX [ libX11.dev libGLU.dev libGL.dev libXpm.dev libXext.dev libXxf86vm.dev alsaLib.dev ]
-      ++ lib.optional withSDL [ SDL2.dev ];
+  prePatch = ''
+    patchShebangs source/qcsrc/tools
+  '';
 
-    sourceRoot = "Xonotic/source/darkplaces";
+  buildPhase = ''
+    export PATH=$PATH:$PWD/source/gmqcc/
+    make all-zip-source -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES
+  '';
 
-    # "debug", "release", "profile"
-    target = "release";
+  installPhase = ''
+    PREFIX="$out" make install
+    cp key_0.d0pk "$out"/lib/xonotic/
+  '';
 
-    dontStrip = target != "release";
+  curl = pkgs.curl;
+  libGL = pkgs.libGL;
+  zlib = pkgs.zlib;
+  gcc = pkgs.gcc;
+  freetype = pkgs.freetype;
+  libpng = pkgs.libpng;
+  libtheora = pkgs.libtheora;
+  libvorbis = pkgs.libvorbis;
+  libogg = pkgs.libogg;
 
-    buildPhase = lib.optionalString withDedicated ''
-      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sv-${target}
-    '' + lib.optionalString withGLX ''
-      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES cl-${target}
-    '' + lib.optionalString withSDL ''
-      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sdl-${target}
-    '';
-
-    enableParallelBuilding = true;
-
-    installPhase = ''
-      for size in 16x16 24x24 32x32 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 1024x1024 scalable; do
-        install -Dm644 ../../misc/logos/xonotic_icon.svg \
-          $out/share/icons/hicolor/$size/xonotic.svg
-      done
-    '' + lib.optionalString withDedicated ''
-      install -Dm755 darkplaces-dedicated "$out/bin/xonotic-dedicated"
-    '' + lib.optionalString withGLX ''
-      install -Dm755 darkplaces-glx "$out/bin/xonotic-glx"
-    '' + lib.optionalString withSDL ''
-      install -Dm755 darkplaces-sdl "$out/bin/xonotic-sdl"
-    '';
-
-    # Xonotic needs to find libcurl.so at runtime for map downloads
-    dontPatchELF = true;
-    postFixup = lib.optionalString withDedicated ''
-      patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-dedicated
-    '' + lib.optionalString withGLX ''
-      patchelf \
-          --add-needed ${curl.out}/lib/libcurl.so \
-          --add-needed ${libvorbis}/lib/libvorbisfile.so \
-          --add-needed ${libvorbis}/lib/libvorbis.so \
-          --add-needed ${libGL.out}/lib/libGL.so \
-          $out/bin/xonotic-glx
-    '' + lib.optionalString withSDL ''
-      patchelf \
-          --add-needed ${curl.out}/lib/libcurl.so \
-          --add-needed ${libvorbis}/lib/libvorbisfile.so \
-          --add-needed ${libvorbis}/lib/libvorbis.so \
-          $out/bin/xonotic-sdl
-    '';
-  };
-
-in rec {
-  xonotic-data = fetchzip {
-    name = "xonotic-data-${version}";
-    url = "https://dl.xonotic.org/${name}.zip";
-    sha256 = "1ygkh0v68y4sd1w5vpk8dgb65h5jm599hwszdfgjp3ax4d3ml81x";
-    extraPostFetch = ''
-      cd $out
-      rm -rf $(ls | grep -v "^data$")
-    '';
-    meta.hydraPlatforms = [];
-    passthru.version = version;
-  };
-
-  xonotic = runCommandNoCC "xonotic${variant}-${version}" {
-    inherit xonotic-unwrapped;
-    buildInputs = [ makeWrapper ];
-    passthru = {
-      inherit version;
-      meta = meta // {
-        hydraPlatforms = [];
-      };
-    };
-  } (''
-    mkdir -p $out/bin
-  '' + lib.optionalString withDedicated ''
-    ln -s ${xonotic-unwrapped}/bin/xonotic-dedicated $out/bin/
-  '' + lib.optionalString withGLX ''
-    ln -s ${xonotic-unwrapped}/bin/xonotic-glx $out/bin/xonotic-glx
-    ln -s $out/bin/xonotic-glx $out/bin/xonotic
-  '' + lib.optionalString withSDL ''
-    ln -s ${xonotic-unwrapped}/bin/xonotic-sdl $out/bin/xonotic-sdl
-    ln -sf $out/bin/xonotic-sdl $out/bin/xonotic
-  '' + lib.optionalString (withSDL || withGLX) ''
-    mkdir -p $out/share
-    ln -s ${xonotic-unwrapped}/share/icons $out/share/icons
-    ${desktopItem.buildCommand}
-  '' + ''
-    for binary in $out/bin/xonotic-*; do
-      wrapProgram $binary --add-flags "-basedir ${xonotic-data}"
-    done
-  '');
+  # --add-needed ${gcc.out}/lib/libstdc++.so.6 \
+  postFixup = ''
+    patchelf \
+        --add-needed ${curl.out}/lib/libcurl.so \
+        --add-needed ${zlib.out}/lib/libz.so \
+        $out/lib/xonotic/xonotic-linux64-dedicated
+    patchelf \
+        --add-needed ${curl.out}/lib/libcurl.so \
+        --add-needed ${libvorbis.out}/lib/libvorbisfile.so \
+        --add-needed ${libvorbis.out}/lib/libvorbis.so \
+        --add-needed ${libGL.out}/lib/libGL.so \
+        --add-needed ${zlib.out}/lib/libz.so \
+        --add-needed ${libtheora.out}/lib/libtheora.so \
+        --add-needed ${libtheora.out}/lib/libtheoraenc.so \
+        --add-needed ${libtheora.out}/lib/libtheoradec.so \
+        --add-needed ${libvorbis.out}/lib/libvorbisenc.so \
+        --add-needed ${libpng.out}/lib/libpng16.so \
+        --add-needed ${freetype.out}/lib/libfreetype.so \
+        $out/lib/xonotic/xonotic-linux64-glx
+    patchelf \
+        --add-needed ${curl.out}/lib/libcurl.so \
+        --add-needed ${libvorbis.out}/lib/libvorbisfile.so \
+        --add-needed ${libvorbis.out}/lib/libvorbis.so \
+        --add-needed ${libGL.out}/lib/libGL.so \
+        --add-needed ${zlib.out}/lib/libz.so \
+        --add-needed ${libtheora.out}/lib/libtheora.so \
+        --add-needed ${libtheora.out}/lib/libtheoraenc.so \
+        --add-needed ${libtheora.out}/lib/libtheoradec.so \
+        --add-needed ${libvorbis.out}/lib/libvorbisenc.so \
+        --add-needed ${libpng.out}/lib/libpng16.so \
+         --add-needed ${freetype.out}/lib/libfreetype.so \
+        $out/lib/xonotic/xonotic-linux64-sdl
+  '';
 }
+


### PR DESCRIPTION
- Build all three binaries (sdl, glx, server)
- build player UID infrastructure
- locate and add more libraries looked up at runtime:
  - fix font (uses the xonolonium font now) (libfreetype)
  - add libtheora/enc/dev libvorbis/enc/file 
- copy public key over to installation directory, so player UIDs work

this looks to me now like a mostly functioning version of xonotic. The build is linux specific though

I do not expect this PR to merge, but the maintainers of the original package might have a look and incorporate some of the changes.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

xonotic player ID tracking was broken in the original package. Also a font was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
